### PR TITLE
Add Documentation parameter into template definition

### DIFF
--- a/server/src/main/scala/de/frosner/broccoli/models/Template.scala
+++ b/server/src/main/scala/de/frosner/broccoli/models/Template.scala
@@ -6,7 +6,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json._
 
-case class Template(id: String, template: String, description: String, parameterInfos: Map[String, ParameterInfo])
+case class Template(id: String, template: String, documentation_url: String, description: String, parameterInfos: Map[String, ParameterInfo])
     extends Serializable {
 
   @transient
@@ -38,11 +38,12 @@ object Template {
     (
       (JsPath \ "id").write[String] and
         (JsPath \ "description").write[String] and
+        (JsPath \ "documentation_url").write[String] and
         (JsPath \ "parameters").write[Seq[String]] and
         (JsPath \ "parameterInfos").write[Map[String, ParameterInfo]](paramInfoMapWrites) and
         (JsPath \ "version").write[String]
     )((template: Template) =>
-      (template.id, template.description, template.sortedParameters, template.parameterInfos, template.version))
+      (template.id, template.description, template.documentation_url, template.sortedParameters, template.parameterInfos, template.version))
 
   implicit val templatePersistenceReads: Reads[Template] = Json.reads[Template]
 

--- a/server/src/main/scala/de/frosner/broccoli/templates/TemplateConfig.scala
+++ b/server/src/main/scala/de/frosner/broccoli/templates/TemplateConfig.scala
@@ -17,6 +17,7 @@ object TemplateConfig {
         val confObj = configOrig.asInstanceOf[ConfigObject]
         val config = confObj.toConfig
         val description = Try(config.getString("description")).toOption
+        val documentation_url = Try(config.getString("documentation_url")).toOption
         val parameters = config
           .getObject("parameters")
           .map {
@@ -42,7 +43,7 @@ object TemplateConfig {
               (paramName, Parameter(maybeName, maybeDefault, maybeSecret, paramType, maybeOrderIndex))
           }
           .toMap
-        TemplateInfo(description, parameters)
+        TemplateInfo(description, documentation_url, parameters)
       } match {
         case Success(e)  => Right(e)
         case Failure(ex) =>
@@ -51,7 +52,7 @@ object TemplateConfig {
       }
   }
 
-  final case class TemplateInfo(description: Option[String], parameters: Map[String, Parameter])
+  final case class TemplateInfo(description: Option[String], documentation_url: Option[String], parameters: Map[String, Parameter])
 
   final case class Parameter(name: Option[String],
                              default: Option[ParameterValue],
@@ -59,4 +60,4 @@ object TemplateConfig {
                              `type`: ParameterType,
                              orderIndex: Option[Int])
 
-}
+} 

--- a/server/src/main/scala/de/frosner/broccoli/templates/TemplateSource.scala
+++ b/server/src/main/scala/de/frosner/broccoli/templates/TemplateSource.scala
@@ -37,6 +37,7 @@ trait TemplateSource {
         id = templateId,
         template = templateString,
         description = templateInfo.description.getOrElse(s"$templateId template"),
+        documentation_url = templateInfo.documentation_url.getOrElse(s""),
         parameterInfos = templateInfo.parameters
           .map { case (id, parameter) => id -> ParameterInfo.fromTemplateInfoParameter(id, parameter) }
       )

--- a/server/src/test/resources/de/frosner/broccoli/templates/curl-without-documentation/template.conf
+++ b/server/src/test/resources/de/frosner/broccoli/templates/curl-without-documentation/template.conf
@@ -1,4 +1,4 @@
-documentation_url = "#curl-test-docs"
+description = "A periodic job that sends an HTTP GET request to a specified address every minute."
 parameters = {
   "id" = {
     type = raw

--- a/server/src/test/resources/de/frosner/broccoli/templates/curl-without-documentation/template.json
+++ b/server/src/test/resources/de/frosner/broccoli/templates/curl-without-documentation/template.json
@@ -1,0 +1,82 @@
+{
+    "Job": {
+        "Region": "global",
+        "ID": "{{id}}",
+        "Name": "{{id}}",
+        "Type": "batch",
+        "Priority": 50,
+        "AllAtOnce": false,
+        "Datacenters": [
+            "dc1"
+        ],
+        "Constraints": null,
+        "TaskGroups": [
+            {
+                "Name": "curl-group",
+                "Count": 1,
+                "Constraints": null,
+                "Tasks": [
+                    {
+                        "Name": "curl-task",
+                        "Driver": "raw_exec",
+                        "User": "",
+                        "Config": {
+                            "args": [
+                                "{{URL}}"
+                            ],
+                            "command": "/usr/bin/curl"
+                        },
+                        "Constraints": null,
+                        "Env": null,
+                        "Services": [],
+                        "Resources": {
+                            "CPU": 50,
+                            "MemoryMB": 128,
+                            "DiskMB": 500,
+                            "IOPS": 0,
+                            "Networks": [
+                                {
+                                    "Public": false,
+                                    "CIDR": "",
+                                    "ReservedPorts": null,
+                                    "DynamicPorts": null,
+                                    "IP": "",
+                                    "MBits": 10
+                                }
+                            ]
+                        },
+                        "Meta": null,
+                        "KillTimeout": 5000000000,
+                        "LogConfig": {
+                            "MaxFiles": 10,
+                            "MaxFileSizeMB": 10
+                        },
+                        "Artifacts": null
+                    }
+                ],
+                "RestartPolicy": {
+                    "Interval": 60000000000,
+                    "Attempts": 2,
+                    "Delay": 15000000000,
+                    "Mode": "delay"
+                },
+                "Meta": null
+            }
+        ],
+        "Update": {
+            "Stagger": 0,
+            "MaxParallel": 0
+        },
+        "Periodic": {
+            "Enabled": {{enabled}},
+            "Spec": "0 0/1 * 1/1 * ? *",
+            "SpecType": "cron",
+            "ProhibitOverlap": true
+        },
+        "Meta": null,
+        "Status": "",
+        "StatusDescription": "",
+        "CreateIndex": 0,
+        "ModifyIndex": 0
+    }
+}

--- a/server/src/test/resources/de/frosner/broccoli/templates/curl/template.conf
+++ b/server/src/test/resources/de/frosner/broccoli/templates/curl/template.conf
@@ -1,5 +1,5 @@
 description = "A periodic job that sends an HTTP GET request to a specified address every minute."
-
+documentation_url = "#curl-test-docs"
 parameters = {
   "id" = {
     type = raw

--- a/server/src/test/scala/de/frosner/broccoli/controllers/InstanceControllerSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/controllers/InstanceControllerSpec.scala
@@ -65,6 +65,7 @@ class InstanceControllerSpec
         id = "t",
         template = "{{id}} {{secret}}",
         description = "d",
+        documentation_url = "docs"
         parameterInfos = Map(
           "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
           "secret" -> ParameterInfo(

--- a/server/src/test/scala/de/frosner/broccoli/controllers/InstanceControllerSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/controllers/InstanceControllerSpec.scala
@@ -65,7 +65,7 @@ class InstanceControllerSpec
         id = "t",
         template = "{{id}} {{secret}}",
         description = "d",
-        documentation_url = "docs"
+        documentation_url = "docs",
         parameterInfos = Map(
           "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
           "secret" -> ParameterInfo(

--- a/server/src/test/scala/de/frosner/broccoli/controllers/TemplateControllerSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/controllers/TemplateControllerSpec.scala
@@ -45,6 +45,7 @@ class TemplateControllerSpec extends PlaySpecification with AuthUtils {
               JsObject(Map(
                 "id" -> JsString(template.id),
                 "parameters" -> JsArray(Seq(JsString("id"))),
+                "documentation_url" -> JsString("#documentation_url"),
                 "parameterInfos" -> JsObject(Map(
                   "id" -> JsObject(Map(
                     "id" -> JsString("id"),
@@ -96,6 +97,7 @@ class TemplateControllerSpec extends PlaySpecification with AuthUtils {
             Map(
               "id" -> JsString(template.id),
               "parameters" -> JsArray(Seq(JsString("id"))),
+              "documentation_url" -> JsString("#documentation_url"),
               "parameterInfos" -> JsObject(Map(
                 "id" -> JsObject(Map(
                   "id" -> JsString("id"),

--- a/server/src/test/scala/de/frosner/broccoli/controllers/TemplateControllerSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/controllers/TemplateControllerSpec.scala
@@ -18,6 +18,7 @@ class TemplateControllerSpec extends PlaySpecification with AuthUtils {
         id = "id",
         template = "template {{id}}",
         description = "description",
+        documentation_url = "#documentation_url",
         parameterInfos = Map(
           "id" -> ParameterInfo(id = "id",
                                 name = Some("myname"),
@@ -69,6 +70,7 @@ class TemplateControllerSpec extends PlaySpecification with AuthUtils {
         id = "id",
         template = "template {{id}}",
         description = "description",
+        documentation_url = "#documentation_url",
         parameterInfos = Map(
           "id" -> ParameterInfo(id = "id",
                                 name = Some("myname"),

--- a/server/src/test/scala/de/frosner/broccoli/controllers/WebSocketControllerSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/controllers/WebSocketControllerSpec.scala
@@ -35,6 +35,7 @@ class WebSocketControllerSpec
         id = "t",
         template = "{{id}} {{secret}}",
         description = "d",
+        documentation_url = "#documentation_url",
         parameterInfos = Map(
           "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
           "secret" -> ParameterInfo(

--- a/server/src/test/scala/de/frosner/broccoli/instances/NomadInstancesSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/instances/NomadInstancesSpec.scala
@@ -36,6 +36,7 @@ class NomadInstancesSpec
         id = "id",
         template = "{{id}}",
         description = "description",
+        documentation_url = "#documentation_url",
         parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))
       ),
       parameterValues = Map("id" -> StringParameterValue("id"))

--- a/server/src/test/scala/de/frosner/broccoli/instances/storage/InstanceStorageSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/instances/storage/InstanceStorageSpec.scala
@@ -57,6 +57,7 @@ class InstanceStorageSpec extends Specification {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "#documentation_url",
           parameterInfos = Map(
             "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
             "age" -> ParameterInfo("age",
@@ -81,6 +82,7 @@ class InstanceStorageSpec extends Specification {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "#documentation_url",
           parameterInfos = Map(
             "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
             "age" -> ParameterInfo("age",

--- a/server/src/test/scala/de/frosner/broccoli/instances/storage/couchdb/CouchDBInstanceStorageSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/instances/storage/couchdb/CouchDBInstanceStorageSpec.scala
@@ -21,6 +21,7 @@ class CouchDBInstanceStorageSpec extends Specification {
     template = Template(id = "t",
                         template = "{{id}}",
                         description = "d",
+                        documentation_url = "#documentation_url",
                         parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))),
     parameterValues = Map(
       "id" -> RawParameterValue("prefix-id")

--- a/server/src/test/scala/de/frosner/broccoli/instances/storage/filesystem/FileSystemInstanceStorageSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/instances/storage/filesystem/FileSystemInstanceStorageSpec.scala
@@ -19,6 +19,7 @@ class FileSystemInstanceStorageSpec extends Specification with TemporaryDirector
     template = Template(id = "t",
                         template = "{{id}}",
                         description = "d",
+                        documentation_url = "#link-to-documentation",
                         parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))),
     parameterValues = Map(
       "id" -> RawParameterValue("prefix-id")

--- a/server/src/test/scala/de/frosner/broccoli/models/InstanceSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/models/InstanceSpec.scala
@@ -22,14 +22,14 @@ class InstanceSpec extends Specification with ScalaCheck with ModelArbitraries w
     "be possible to construct if the parameters to be filled match the ones in the template's parameter infos" in {
       val parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))
       val instance1 =
-        Instance("1", Template("1", "\"{{id}}\"", "desc", parameterInfos), Map("id" -> RawParameterValue("Heinz")))
+        Instance("1", Template("1", "\"{{id}}\"", "desc", "#doc-url", parameterInfos), Map("id" -> RawParameterValue("Heinz")))
       val instance2 =
-        Instance("1", Template("1", "\"{{id}}\"", "desc", parameterInfos), Map("id" -> RawParameterValue("Heinz")))
+        Instance("1", Template("1", "\"{{id}}\"", "desc", "#doc-url",parameterInfos), Map("id" -> RawParameterValue("Heinz")))
       instance1 === instance2
     }
 
     "throw an exception during construction if not all variables are specified in the template's parameter infos" in {
-      Instance("1", Template("1", "\"{{id}}\"", "desc", Map.empty), Map("id" -> RawParameterValue("Heinz"))) must throwA(
+      Instance("1", Template("1", "\"{{id}}\"", "desc", "#doc-url",Map.empty), Map("id" -> RawParameterValue("Heinz"))) must throwA(
         new IllegalArgumentException(
           "requirement failed: The given parameters values (Set(id)) need to match the ones in the template (Set()) (instance id 1)."))
     }

--- a/server/src/test/scala/de/frosner/broccoli/models/InstanceWithStatusSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/models/InstanceWithStatusSpec.scala
@@ -19,6 +19,7 @@ class InstanceWithStatusSpec extends Specification with ScalaCheck with ModelArb
             id = "t",
             template = "{{id}} {{password}}",
             description = "d",
+            documentation_url = "#link-to-documentation",
             parameterInfos = Map(
               "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
               "password" -> ParameterInfo(
@@ -47,6 +48,7 @@ class InstanceWithStatusSpec extends Specification with ScalaCheck with ModelArb
             id = "t",
             template = "{{id}} {{password}}",
             description = "d",
+            documentation_url = "#link-to-documentation",
             parameterInfos = Map(
               "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
               "password" -> ParameterInfo(
@@ -79,6 +81,7 @@ class InstanceWithStatusSpec extends Specification with ScalaCheck with ModelArb
             id = "t",
             template = "{{id}} {{password}}",
             description = "d",
+            documentation_url = "#link-to-documentation",
             parameterInfos = Map(
               "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
               "password" -> ParameterInfo(
@@ -115,6 +118,7 @@ class InstanceWithStatusSpec extends Specification with ScalaCheck with ModelArb
             id = "t",
             template = "{{id}} {{password}}",
             description = "d",
+            documentation_url = "#link-to-documentation",
             parameterInfos = Map(
               "password" -> ParameterInfo(
                 id = "secret password",

--- a/server/src/test/scala/de/frosner/broccoli/models/ModelArbitraries.scala
+++ b/server/src/test/scala/de/frosner/broccoli/models/ModelArbitraries.scala
@@ -66,6 +66,7 @@ trait ModelArbitraries {
     for {
       templateId <- Gen.identifier.label("id")
       templateDescription <- Gen.identifier.label("description")
+      templateDocURL <- Gen.identifier.label("documentation_url")
       templateParameters <- Gen.listOf(arbParameterInfo.arbitrary).label("parameterInfos")
     } yield {
       val idParameter = ParameterInfo(id = "id", None, None, None, ParameterType.String, None)
@@ -73,6 +74,7 @@ trait ModelArbitraries {
       Template(
         id = templateId,
         description = templateDescription,
+        documentation_url = templateDocURL,
         // Templates require an "id" parameter so add one here
         template = s"{{id}} $template",
         parameterInfos = templateParameters.map(i => i.id -> i).toMap + ("id" -> idParameter)

--- a/server/src/test/scala/de/frosner/broccoli/models/TemplateSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/models/TemplateSpec.scala
@@ -15,21 +15,23 @@ class TemplateSpec extends Specification {
       Template("test",
                "Hallo {{id}}. I like {{person_name}}.",
                "desc",
+               "#link-to-docs",
                Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))).parameters === Set("id")
     }
 
     "not automatically extract parameters from a template" in {
-      Template("test", "Hallo {{id}}, how is {{object}}", "desc", Map.empty).parameters === Set.empty
+      Template("test", "Hallo {{id}}, how is {{object}}", "desc", "#link-to-docs", Map.empty).parameters === Set.empty
     }
 
     "create the template version correctly in" in {
-      Template("test", "template JSON", "desc", Map.empty).version === "889df4c8118c30a28ed4f51674a0f19d"
+      Template("test", "template JSON", "desc", "#link-to-docs", Map.empty).version === "889df4c8118c30a28ed4f51674a0f19d"
     }
 
     "result in different template versions if the template JSON differs" in {
-      Template("test", "template JSON", "desc", Map.empty).version !== Template("test",
+      Template("test", "template JSON", "desc", "#link-to-docs", Map.empty).version !== Template("test",
                                                                                 "template JSONs",
                                                                                 "desc",
+                                                                                "#link-to-docs",
                                                                                 Map.empty).version
     }
 
@@ -38,11 +40,13 @@ class TemplateSpec extends Specification {
         id = "test",
         template = "template JSON {{id}}",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map.empty
       ).version !== Template(
         id = "test",
         template = "template JSON {{id}}",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map(
           "id" -> ParameterInfo("id",
                                 None,
@@ -59,7 +63,7 @@ class TemplateSpec extends Specification {
   "Template serialization" should {
 
     "work correctly" in {
-      val originalTemplate = Template("test", "Hallo {{name}}", "desc", Map.empty)
+      val originalTemplate = Template("test", "Hallo {{name}}", "desc", "#docs_url", Map.empty)
       val bos = new ByteArrayOutputStream()
       val oos = new ObjectOutputStream(bos)
       oos.writeObject(originalTemplate)
@@ -81,6 +85,7 @@ class TemplateSpec extends Specification {
         id = "t",
         template = "{{id}}",
         description = "d",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map.empty
       )
       Json

--- a/server/src/test/scala/de/frosner/broccoli/services/InstanceServiceSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/services/InstanceServiceSpec.scala
@@ -35,6 +35,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "#link-to-documentation",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                                "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None))
         ),
@@ -52,6 +53,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "#link-to-documentation",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                                "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None))
         ),
@@ -69,6 +71,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "#link-to-documentation",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                                "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None))
         ),
@@ -86,6 +89,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
         id = "1",
         template = "\"{{id}} {{age}}\"",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                              "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None))
       )
@@ -93,6 +97,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
         id = "5",
         template = "\"{{id}} {{age}}\"",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                              "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None))
       )
@@ -112,6 +117,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
         id = "1",
         template = "\"{{id}} {{age}}\"",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                              "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None))
       )
@@ -119,6 +125,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
         id = "5",
         template = "\"{{id}} {{age}} {{height}}\"",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map(
           "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
           "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None),
@@ -141,6 +148,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
         id = "1",
         template = "\"{{id}} {{age}}\"",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                              "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None))
       )
@@ -148,6 +156,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
         id = "5",
         template = "\"{{id}} {{age}} {{height}}\"",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map(
           "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
           "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None),
@@ -170,6 +179,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
         id = "1",
         template = "\"{{id}} {{age}}\"",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                              "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None))
       )
@@ -177,6 +187,7 @@ class InstanceServiceSpec extends Specification with Mockito with ServiceMocks {
         id = "5",
         template = "\"{{id}} {{age}} {{height}}\"",
         description = "desc",
+        documentation_url = "#link-to-documentation",
         parameterInfos = Map(
           "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
           "age" -> ParameterInfo("age", None, None, None, ParameterType.Raw, None),

--- a/server/src/test/scala/de/frosner/broccoli/templates/DirectoryTemplateSourceSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/templates/DirectoryTemplateSourceSpec.scala
@@ -33,6 +33,7 @@ class DirectoryTemplateSourceSpec extends Specification with TemporaryTemplatesC
           "curl",
           Source.fromFile(templatesDirectory.resolve("curl/template.json").toFile).mkString,
           "A periodic job that sends an HTTP GET request to a specified address every minute.",
+          "#curl-test-docs",
           Map(
             "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, Some(0)),
             "URL" -> ParameterInfo("URL",

--- a/server/src/test/scala/de/frosner/broccoli/templates/DirectoryTemplateSourceSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/templates/DirectoryTemplateSourceSpec.scala
@@ -32,8 +32,8 @@ class DirectoryTemplateSourceSpec extends Specification with TemporaryTemplatesC
         beEqualTo(Template(
           "curl",
           Source.fromFile(templatesDirectory.resolve("curl/template.json").toFile).mkString,
-          "A periodic job that sends an HTTP GET request to a specified address every minute.",
           "#curl-test-docs",
+          "A periodic job that sends an HTTP GET request to a specified address every minute.",
           Map(
             "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, Some(0)),
             "URL" -> ParameterInfo("URL",

--- a/server/src/test/scala/de/frosner/broccoli/templates/TemplateConfigSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/templates/TemplateConfigSpec.scala
@@ -16,6 +16,8 @@ class TemplateConfigSpec extends Specification {
         """
                   |description = "A periodic job that sends an HTTP GET request to a specified address every minute."
                   |
+                  |documentation_url = "#link-to-documentation"
+                  |
                   |parameters = {
                   |  "URL" = {
                   |    name = "connection url"
@@ -43,6 +45,7 @@ class TemplateConfigSpec extends Specification {
                 """.stripMargin
       val expectedTemplateInfo = TemplateConfig.TemplateInfo(
         description = Some("A periodic job that sends an HTTP GET request to a specified address every minute."),
+        documentation_url = Some("#link-to-documentation"),
         parameters = Map(
           "URL" -> Parameter(
             name = Some("connection url"),
@@ -94,6 +97,8 @@ class TemplateConfigSpec extends Specification {
         """
                   |description = "A periodic job that sends an HTTP GET request to a specified address every minute."
                   |
+                  |documentation_url = "#link-to-documentation"
+                  |
                   |parameters = {
                   |  "URL" = {
                   |    name = "connection url"
@@ -121,6 +126,8 @@ class TemplateConfigSpec extends Specification {
       val configString =
         """
           |description = "A periodic job that sends an HTTP GET request to a specified address every minute."
+          |
+          |documentation_url = "#link-to-documentation"
           |
           |parameters = {
           |  "URL" = {

--- a/server/src/test/scala/de/frosner/broccoli/templates/TemplateRendererSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/templates/TemplateRendererSpec.scala
@@ -20,6 +20,7 @@ class TemplateRendererSpec extends Specification with Mockito {
                  Template("1",
                           "\"{{id}}\"",
                           "desc",
+                          "doc_url",
                           Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))),
                  Map("id" -> StringParameterValue("Frank")))
       templateRenderer.renderJson(instance) === JsString("Frank")
@@ -33,6 +34,7 @@ class TemplateRendererSpec extends Specification with Mockito {
             "1",
             "\"{{id}} {{age}}\"",
             "desc",
+            "doc_url",
             Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
                 "age" -> ParameterInfo("age", None, None, None, ParameterType.Integer, None))
           ),
@@ -48,6 +50,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map(
             "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
             "age" -> ParameterInfo("age",
@@ -70,6 +73,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = """"{{id}}"""",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map(
             "id" -> ParameterInfo("id",
                                   None,
@@ -90,6 +94,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = "\"{{id}}\"",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))
         ),
         parameterValues = Map("id" -> RawParameterValue("^.*$"))
@@ -104,6 +109,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map(
             "id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None),
             "age" ->
@@ -123,6 +129,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = """{{id}}""",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map(
             "id" -> ParameterInfo("id",
                                   None,
@@ -144,6 +151,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = "\"{% for x in [1,2,3] %}{{ id }}{{ x }}{% endfor %}\"",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))
         ),
         parameterValues = Map("id" -> RawParameterValue("1"))
@@ -160,6 +168,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = template,
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))
         ),
         parameterValues = Map("id" -> RawParameterValue("10"))
@@ -172,6 +181,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = template,
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))
         ),
         parameterValues = Map("id" -> RawParameterValue("-3"))
@@ -186,6 +196,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))
         ),
         parameterValues = Map("id" -> RawParameterValue("Frank"))
@@ -203,6 +214,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = "\"{{id}} {{age}}\"",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map("id" -> ParameterInfo("id", None, None, None, ParameterType.Raw, None))
         ),
         parameterValues = Map("id" -> RawParameterValue("Frank"))
@@ -219,6 +231,7 @@ class TemplateRendererSpec extends Specification with Mockito {
           id = "1",
           template = """{{id}}""",
           description = "desc",
+          documentation_url = "doc_url",
           parameterInfos = Map(
             "id" -> ParameterInfo("id",
                                   None,

--- a/server/src/test/scala/de/frosner/broccoli/templates/TemplateSourceSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/templates/TemplateSourceSpec.scala
@@ -29,7 +29,7 @@ class TemplateSourceSpec extends Specification with Mockito {
     "work" in {
       val id = "templateId"
       val templateString = "Hello {{ id }}"
-      val templateInfo = TemplateInfo(None, Map("id" -> Parameter(Some("id"), None, None, ParameterType.Raw, None)))
+      val templateInfo = TemplateInfo(None, None, Map("id" -> Parameter(Some("id"), None, None, ParameterType.Raw, None)))
       val template =
         defaultTemplateSource.loadTemplate(id, templateString, templateInfo).get
 
@@ -39,7 +39,7 @@ class TemplateSourceSpec extends Specification with Mockito {
 
     "require an 'id' parameter (no parameter)" in {
       val tryTemplate =
-        defaultTemplateSource.loadTemplate("test", "Hallo", TemplateInfo(None, Map.empty))
+        defaultTemplateSource.loadTemplate("test", "Hallo", TemplateInfo(None, None, Map.empty))
       (tryTemplate.isFailure must beTrue) and (tryTemplate.failed.get.getMessage must beEqualTo(
         "requirement failed: There needs to be an 'id' field in the template for Broccoli to work. Parameters defined: Set()"))
     }
@@ -49,7 +49,7 @@ class TemplateSourceSpec extends Specification with Mockito {
         defaultTemplateSource.loadTemplate(
           "test",
           "Hallo {{bla}}",
-          TemplateInfo(None, Map("bla" -> Parameter(Some("bla"), None, None, ParameterType.Raw, None)))
+          TemplateInfo(None, None, Map("bla" -> Parameter(Some("bla"), None, None, ParameterType.Raw, None)))
         )
       (tryTemplate.isFailure must beTrue) and (tryTemplate.failed.get.getMessage must beEqualTo(
         "requirement failed: There needs to be an 'id' field in the template for Broccoli to work. Parameters defined: Set(bla)"))
@@ -61,6 +61,7 @@ class TemplateSourceSpec extends Specification with Mockito {
           "test",
           "Hallo {{bla-bla}}",
           TemplateInfo(None,
+                       None,
                        Map("id" -> Parameter(Some("id"), None, None, ParameterType.Raw, None),
                            "bla-bla" -> Parameter(Some("bla"), None, None, ParameterType.Raw, None)))
         )
@@ -74,6 +75,7 @@ class TemplateSourceSpec extends Specification with Mockito {
           "test",
           "{{id}} {{ global_var }} {% for x in [1 2 3] %}{{x}}{% endfor %}",
           TemplateInfo(None,
+                       None,
                        Map("id" -> Parameter(Some("id"), None, None, ParameterType.Raw, None),
                            "global_var" -> Parameter(Some("global_var"), None, None, ParameterType.Raw, None)))
         )

--- a/templates/http-server/template.conf
+++ b/templates/http-server/template.conf
@@ -1,4 +1,5 @@
 description = "A simple Python HTTP request handler. This class serves files from the current directory and below, directly mapping the directory structure to HTTP requests."
+documentation_url = "#http-server"
 parameters {
   cpu {
     name = "CPU Shares"

--- a/templates/jupyter/template.conf
+++ b/templates/jupyter/template.conf
@@ -1,4 +1,5 @@
 description = "Open source, interactive data science and scientific computing across over 40 programming languages."
+documentation_url = "#jupyter"
 parameters {
   id {
     type {

--- a/webui/src/Models/Resources/Template.elm
+++ b/webui/src/Models/Resources/Template.elm
@@ -17,6 +17,7 @@ type alias TemplateId =
 type alias Template =
     { id : TemplateId
     , description : String
+    , documentation_url : String
     , version : String
     , parameters : List String
     , parameterInfos : Dict String ParameterInfo
@@ -55,9 +56,10 @@ addTemplateInstanceString template =
 
 
 decoder =
-    Decode.map5 Template
+    Decode.map6 Template
         (field "id" Decode.string)
         (field "description" Decode.string)
+        (field "documentation_url" Decode.string)
         (field "version" Decode.string)
         (field "parameters" (Decode.list Decode.string))
         (field "parameterInfos" (Decode.dict parameterInfoDecoder))

--- a/webui/src/Views/TemplateView.elm
+++ b/webui/src/Views/TemplateView.elm
@@ -60,6 +60,11 @@ view instances tasks templates bodyUiModel maybeRole template =
                         ]
                         [ p []
                             [ text template.description ]
+                        , (if (String.isEmpty template.documentation_url) then
+                                text "No Documentation available"
+                            else
+                                a [ href template.documentation_url ] [ text "Documentation" ]
+                          )
                         , p []
                             (List.concat
                                 [ if (maybeRole /= Just Administrator) then

--- a/webui/tests/Views/BodySuite.elm
+++ b/webui/tests/Views/BodySuite.elm
@@ -1000,6 +1000,7 @@ defaultTemplate : TemplateId -> Template
 defaultTemplate templateId =
     { id = templateId
     , description = (String.concat [ templateId, "-description" ])
+    , documentation_url = (String.concat [ templateId, "-documentation_url" ])
     , version = (String.concat [ templateId, "-version" ])
     , parameters =
         [ "id"


### PR DESCRIPTION
This MR enables adding of documentation_url into template definition, which currently accepts any URL and renders it under the template description as a href.